### PR TITLE
fix: portable python detection in tests

### DIFF
--- a/tests/test-setup.sh
+++ b/tests/test-setup.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 AGENT_X_HOME="$(cd "$(dirname "$0")/.." && pwd)"
+if python3 --version > /dev/null 2>&1; then PYTHON=python3; else PYTHON=python; fi
 PASS=0
 FAIL=0
 
@@ -46,7 +47,7 @@ assert "core/evolution/ exists" "$([ -d "$AGENT_X_HOME/core/evolution" ] && echo
 
 # Test: Stacks exist
 assert "stacks/registry.json exists" "$([ -f "$AGENT_X_HOME/stacks/registry.json" ] && echo true || echo false)"
-assert "stacks/registry.json is valid JSON" "$(python3 -m json.tool "$AGENT_X_HOME/stacks/registry.json" > /dev/null 2>&1 && echo true || echo false)"
+assert "stacks/registry.json is valid JSON" "$($PYTHON -m json.tool "$AGENT_X_HOME/stacks/registry.json" > /dev/null 2>&1 && echo true || echo false)"
 
 # Test: Profile exists
 assert "profiles/default.json exists" "$([ -f "$AGENT_X_HOME/profiles/default.json" ] && echo true || echo false)"

--- a/tests/test-stacks.sh
+++ b/tests/test-stacks.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 AGENT_X_HOME="$(cd "$(dirname "$0")/.." && pwd)"
+if python3 --version > /dev/null 2>&1; then PYTHON=python3; else PYTHON=python; fi
 PASS=0
 FAIL=0
 
@@ -21,14 +22,14 @@ assert() {
 echo "Testing stack registry..."
 
 # Test: Registry is valid JSON
-assert "registry.json is valid JSON" "$(python3 -m json.tool "$AGENT_X_HOME/stacks/registry.json" > /dev/null 2>&1 && echo true || echo false)"
+assert "registry.json is valid JSON" "$($PYTHON -m json.tool "$AGENT_X_HOME/stacks/registry.json" > /dev/null 2>&1 && echo true || echo false)"
 
 # Test: All stacks in registry have directories
 for stack in nextjs-postgres react-native-expo python-fastapi node-express-mongo static-site; do
   assert "Stack dir exists: $stack" "$([ -d "$AGENT_X_HOME/stacks/$stack" ] && echo true || echo false)"
   assert "stack.json exists: $stack" "$([ -f "$AGENT_X_HOME/stacks/$stack/stack.json" ] && echo true || echo false)"
   assert "template.md exists: $stack" "$([ -f "$AGENT_X_HOME/stacks/$stack/template.md" ] && echo true || echo false)"
-  assert "stack.json valid JSON: $stack" "$(python3 -m json.tool "$AGENT_X_HOME/stacks/$stack/stack.json" > /dev/null 2>&1 && echo true || echo false)"
+  assert "stack.json valid JSON: $stack" "$($PYTHON -m json.tool "$AGENT_X_HOME/stacks/$stack/stack.json" > /dev/null 2>&1 && echo true || echo false)"
 done
 
 echo ""


### PR DESCRIPTION
## Summary
- Fixes test failures on Windows where `python3` is a Store redirect stub
- Uses runtime detection (`python3 --version`) to pick working Python binary
- All 56 tests now pass on both Linux and Windows
- Closes #19

## Test plan
- [x] `bash tests/test-setup.sh` — 22/22 pass
- [x] `bash tests/test-stacks.sh` — 21/21 pass
- [x] `bash tests/test-init.sh` — 10/10 pass
- [x] `bash tests/test-hooks.sh` — 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)